### PR TITLE
change cmake_minimum_required from 3.3 to 2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 2.8)
 project(pktminerg)
 
 option(PROJECT_WITH_PROF "Enable profiling and coverage report analysis" OFF)


### PR DESCRIPTION
Because cent OS default cmake version is 2.8 so change cmake_minimum_required from 3.3 to 2.8.