### PR TITLE
chore: GitHub ops — CI gate, Dependabot, PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## What
+<!-- One or two sentences: what changes. -->
+
+## Why
+<!-- The problem / issue this addresses. -->
+
+## Test evidence
+<!-- Commands run and their result (build + tests), or pcap-replay output for capture changes. -->
+
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/cpdaemon"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "gomod"
+    directory: "/cpctl"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "gomod"
+    directory: "/cpgolib"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "gomod"
+    directory: "/build"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "gomod"
+    directory: "/cptools/dockerpid"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: { interval: "weekly" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake build-essential pkg-config \
-            libpcap-dev libzmq3-dev
+            libpcap-dev autoconf automake libtool
 
       - name: Assemble CPWORKER_LIBRARY_ROOT shim
         run: |
@@ -29,20 +29,19 @@ jobs:
           mkdir -p "$SDK/lib" "$SDK/include"
           # libpcap (shared is fine; cmake uses find_library(pcap ...))
           cp -av /usr/lib/$MA/libpcap.so*  "$SDK/lib/"
-          # libzmq — cmake REQUIRES static libzmq.a (CMakeLists line 84)
-          if [ -f "/usr/lib/$MA/libzmq.a" ]; then
-            cp -av /usr/lib/$MA/libzmq.a "$SDK/lib/"
-          else
-            echo "::warning::libzmq.a not in apt; building static libzmq from source"
-            sudo apt-get install -y autoconf automake libtool
-            git clone --depth 1 https://github.com/zeromq/libzmq /tmp/libzmq
-            ( cd /tmp/libzmq && ./autogen.sh && ./configure --enable-static --disable-shared \
-                && make -j"$(nproc)" && cp src/.libs/libzmq.a "$SDK/lib/" )
-          fi
-          # headers
+          # pcap headers
           cp -av /usr/include/pcap "$SDK/include/" 2>/dev/null || true
           cp -av /usr/include/pcap*.h "$SDK/include/" 2>/dev/null || true
-          cp -av /usr/include/zmq.h /usr/include/zmq_utils.h "$SDK/include/" 2>/dev/null || true
+          # libzmq — build a MINIMAL static lib from source. apt's libzmq.a is a
+          # "fat" build (OpenPGM + GSSAPI) whose pgm_*/gss_* symbols cpworker's
+          # static link can't resolve; disable them for a self-contained archive.
+          git clone --depth 1 https://github.com/zeromq/libzmq /tmp/libzmq
+          ( cd /tmp/libzmq && ./autogen.sh && \
+            ./configure --enable-static --disable-shared \
+              --without-pgm --without-libgssapi_krb5 --disable-libunwind --disable-perf && \
+            make -j"$(nproc)" )
+          cp -av /tmp/libzmq/src/.libs/libzmq.a "$SDK/lib/"
+          cp -av /tmp/libzmq/include/*.h "$SDK/include/"
           ls -l "$SDK/lib" "$SDK/include"
           echo "CPWORKER_LIBRARY_ROOT=$SDK" >> "$GITHUB_ENV"
           echo "CLOUD_PROBE_VERSION=0.9.x-ci" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: ci
+on:
+  pull_request:
+    branches: ["0.9.x"]
+  push:
+    branches: ["0.9.x"]
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install C build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential pkg-config \
+            libpcap-dev libzmq3-dev
+
+      - name: Assemble CPWORKER_LIBRARY_ROOT shim
+        run: |
+          set -euxo pipefail
+          SDK="$RUNNER_TEMP/cpworker-sdk"
+          MA="$(gcc -dumpmachine)"           # e.g. x86_64-linux-gnu
+          mkdir -p "$SDK/lib" "$SDK/include"
+          # libpcap (shared is fine; cmake uses find_library(pcap ...))
+          cp -av /usr/lib/$MA/libpcap.so*  "$SDK/lib/"
+          # libzmq — cmake REQUIRES static libzmq.a (CMakeLists line 84)
+          if [ -f "/usr/lib/$MA/libzmq.a" ]; then
+            cp -av /usr/lib/$MA/libzmq.a "$SDK/lib/"
+          else
+            echo "::warning::libzmq.a not in apt; building static libzmq from source"
+            sudo apt-get install -y autoconf automake libtool
+            git clone --depth 1 https://github.com/zeromq/libzmq /tmp/libzmq
+            ( cd /tmp/libzmq && ./autogen.sh && ./configure --enable-static --disable-shared \
+                && make -j"$(nproc)" && cp src/.libs/libzmq.a "$SDK/lib/" )
+          fi
+          # headers
+          cp -av /usr/include/pcap "$SDK/include/" 2>/dev/null || true
+          cp -av /usr/include/pcap*.h "$SDK/include/" 2>/dev/null || true
+          cp -av /usr/include/zmq.h /usr/include/zmq_utils.h "$SDK/include/" 2>/dev/null || true
+          ls -l "$SDK/lib" "$SDK/include"
+          echo "CPWORKER_LIBRARY_ROOT=$SDK" >> "$GITHUB_ENV"
+          echo "CLOUD_PROBE_VERSION=0.9.x-ci" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cpdaemon/go.mod
+
+      - name: Build (cpworker C + Go) via Mage
+        working-directory: build
+        run: go run mage.go -v build:linux
+
+      - name: Go unit tests
+        run: |
+          set -e
+          for m in cpdaemon cpctl cpgolib; do
+            echo "== go test ./... ($m) =="
+            ( cd "$m" && go test ./... )
+          done


### PR DESCRIPTION
Adds a build+test CI gate (cpworker C via Mage + Go unit tests on PR/push to 0.9.x), Dependabot (gomod across cpdaemon/cpctl/cpgolib/build/cptools/dockerpid + github-actions), and a PR template. Part of the cloud-probe GitHub ops process. No runtime code changes.