### PR TITLE
fix(ci): allow Go toolchain auto-upgrade (GOTOOLCHAIN=auto)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,17 @@ jobs:
 
       - name: Build (cpworker C + Go) via Mage
         working-directory: build
+        # setup-go@v6 pins GOTOOLCHAIN=local, which forbids fetching a newer
+        # toolchain when a (transitive) module requires go > the installed
+        # version. Restore the default 'auto' so the build resolves the
+        # required toolchain on demand, matching local development.
+        env:
+          GOTOOLCHAIN: auto
         run: go run mage.go -v build:linux
 
       - name: Go unit tests
+        env:
+          GOTOOLCHAIN: auto
         run: |
           set -e
           for m in cpdaemon cpctl cpgolib; do


### PR DESCRIPTION
## Problem

The `ci` workflow has failed on **every `0.9.x` run since 2026-06-15** — the run
immediately after the `actions/setup-go` v5→v6 bump (#215). Every run dies during
the Mage build with a bare:

```
Error: exit status 1
```

right after the cpworker `libpcap` install line, with no diagnostic — because
`mage` runs the Go and C builds **concurrently**, so the real error interleaves
and the C-install happens to be the last stdout flushed. It looked like a libpcap
symlink failure; it is not.

## Root cause

The actual error (buried in the concurrent output):

```
go: go.mod requires go >= 1.26.0 (running go 1.25.0; GOTOOLCHAIN=local)
```

`actions/setup-go@v6` installs Go from `cpdaemon/go.mod` (**1.25.0**) and pins
**`GOTOOLCHAIN=local`**, which forbids Go from fetching a newer toolchain. A
transitive dependency now requires **go ≥ 1.26.0**, so the `go build` fails.
Local development builds fine on go 1.24.1 only because the default
`GOTOOLCHAIN=auto` silently fetches the required toolchain — the exact behaviour
`setup-go@v6` disabled.

## Fix

Set `GOTOOLCHAIN: auto` on the build and Go-test steps so CI resolves the
required toolchain on demand, matching local development.

## Verification

- `GOTOOLCHAIN=local` locally **reproduces** the failure
  (`go.mod requires go >= 1.25.0 (running go 1.24.1; GOTOOLCHAIN=local)`).
- Default `auto` builds green — `just verify` (cpworker C build + Go tests) passes
  on go 1.24.1 via auto-upgrade.
- The CI run on this PR is the end-to-end confirmation.
